### PR TITLE
Created RAG memory for the chat agents, fixes #5

### DIFF
--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -15,3 +15,5 @@ sqlalchemy
 psycopg2-binary
 python-multipart
 aiofiles
+sentence-transformers
+chromadb


### PR DESCRIPTION
The new approach only uses rag and not the previous 5 messages. Even alone with RAG, the free llms are struggling, so giving the previous 5 messages would make the load heavier on the free groq llms.